### PR TITLE
rpc: drain fifo's on deinit

### DIFF
--- a/src/rpc.zig
+++ b/src/rpc.zig
@@ -131,7 +131,13 @@ pub fn rpcClientType(
         /// deinit
         pub fn deinit(self: *Self) void {
             self.method_hash_map.deinit();
+            while (self.req_fifo.readItem()) |val| {
+                self.freePayload(val);
+            }
             self.req_fifo.deinit();
+            while (self.res_fifo.readItem()) |val| {
+                self.freePayload(val);
+            }
             self.res_fifo.deinit();
             self.allocator.destroy(self.writer_ptr);
             self.allocator.destroy(self.reader_ptr);


### PR DESCRIPTION
It is possible to exit the client without explicitly draining one of the fifos, specifically the response fifo can contain payloads which have not been read. Drain the fifo queues and free any remaining payloads when deinit'ing the client